### PR TITLE
Set default directory to current file's directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ### Install
 
-You must install nnn itself. Instructions [here](https://github.com/jarun/nnn#installation).
+You must install nnn itself. Instructions
+[here](https://github.com/jarun/nnn#installation).
 
 Then install using your favorite plugin manager:
 
@@ -14,16 +15,26 @@ Plug 'mcchrish/nnn.vim'
 ### Usage
 
 To open nnn as a file picker in vim/neovim, use the command `:NnnPicker` or
-`:Np` or the key-binding `<leader>n`. Once you select one or more files and quit
-nnn, vim/neovim will open the first selected file and add the remaining files to
-the arg list/buffer list. If no file is explicitly selected, the last selected
-entry is picked.
+`:Np` or the key-binding `<leader>n`. You can pass a directory to `:NnnPicker`
+command and opens nnn from there e.g. `:NnnPicker path/to/somewhere`.
+
+Once you select one or more files and quit nnn, vim/neovim will open the first
+selected file and add the remaining files to the arg list/buffer list. If no
+file is explicitly selected, the last selected entry is picked.
 
 #### Custom mappings
 
 ```vim
+" Disable default mappings
 let g:nnn#set_default_mappings = 0
+
+" Then set your own
 nnoremap <leader>nn :NnnPicker<CR>
+
+
+" Or override
+" Start nnn in the current file's directory
+nnoremap <leader>n :NnnPicker '%:p:h'<CR>
 ```
 
 #### Notes

--- a/plugin/nnn.vim
+++ b/plugin/nnn.vim
@@ -41,7 +41,7 @@ fun! s:evaluate_temp()
     redraw!
 endfun
 
-function! NnnPicker()
+function! NnnPicker(...)
     let l:directory = get(a:, 1, expand('%:p:h'))
     let s:temp = tempname()
     let l:cmd = 'nnn -p ' . shellescape(s:temp) . ' ' . l:directory

--- a/plugin/nnn.vim
+++ b/plugin/nnn.vim
@@ -42,8 +42,9 @@ fun! s:evaluate_temp()
 endfun
 
 function! NnnPicker()
+    let l:directory = get(a:, 1, expand('%:p:h'))
     let s:temp = tempname()
-    let l:cmd = 'nnn -p ' . shellescape(s:temp)
+    let l:cmd = 'nnn -p ' . shellescape(s:temp) . ' ' . l:directory
 
     if has("nvim")
       enew
@@ -57,8 +58,8 @@ function! NnnPicker()
     endif
 endfunction
 
-command! -bar NnnPicker call NnnPicker()
-command! -nargs=* -complete=file Np :call NnnPicker()
+command! -bar -nargs=? -complete=dir NnnPicker call NnnPicker(<f-args>)
+command! -bar -nargs=? -complete=dir Np :call NnnPicker(<f-args>)
 
 if g:nnn#set_default_mappings
     nnoremap <leader>n :<C-U>NnnPicker<CR>

--- a/plugin/nnn.vim
+++ b/plugin/nnn.vim
@@ -42,7 +42,7 @@ fun! s:evaluate_temp()
 endfun
 
 function! NnnPicker(...)
-    let l:directory = get(a:, 1, expand('%:p:h'))
+    let l:directory = get(a:, 1, '')
     let s:temp = tempname()
     let l:cmd = 'nnn -p ' . shellescape(s:temp) . ' ' . l:directory
 


### PR DESCRIPTION
When opened without arguments, nnn will use the expansion of `%:p:h`,
the head of the path of the current file. If the user provides
a directory, that will be used instead.