### PR TITLE
Add notes on discard selection, pressing `Enter`

### DIFF
--- a/plugin/nnn.vim
+++ b/plugin/nnn.vim
@@ -13,6 +13,10 @@
 " quit nnn, vim/neovim will open the first selected file and add the remaining
 " files to the arg list/buffer list.  If no file is explicitly selected, the
 " last selected entry is picked.
+"
+" Notes:
+" 1. To discard selection and exit, press `^G`.
+" 2. Pressing `Enter` on a file in `nnn` will open the file instead if picking.
 
 let s:temp = ""
 
@@ -48,7 +52,7 @@ endfun
 function! NnnPicker()
     let s:temp = tempname()
     let l:cmd = 'nnn -p ' . shellescape(s:temp)
-    
+
     if has("nvim")
       enew
       call termopen(l:cmd, {'on_exit': function('s:T_OnExit')}) | startinsert


### PR DESCRIPTION
- key `^G` will discard selection and exit
- added some more notes on the plugin usage

@mcchrish please run and test the behaviour when `^G` is pressed. `nnn` changes are available in `nnn` master branch.