### PR TITLE
make nnn#action feature work again

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ let g:nnn#action = {
       \ '<c-v>': 'vsplit' }
 ```
 
+For example, when inside an nnn window, pressing <kbd>ctrl-t</kbd> will open the
+selected file in a tab, instead of the current window. <kbd>ctrl-x</kbd> will
+open in a split an so on. Meanwhile for multi selected files will be loaded in the
+buffer list.
+
 #### `nnn#pick()`
 
 The `nnn#pick([<dir>][,<opts>])` function can be called with custom directory

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -72,12 +72,21 @@ fun! s:eval_temp(opts) abort
         " Nothing to read.
         return
     endif
-    let l:names = filter(split(readfile(s:temp)[0], "\\n"), '!isdirectory(v:val)')
+
+    let l:file = readfile(s:temp)
+    if empty(l:file)
+        redraw!
+        " Nothing to open.
+        return
+    endif
+
+    let l:names = filter(split(l:file[0], "\\n"), '!isdirectory(v:val)')
     if empty(l:names)
         redraw!
         " Nothing to open.
         return
     endif
+
     " Edit the first item.
     let l:cmd = strlen(s:action) > 0 ? s:action : a:opts.edit
     exec l:cmd . ' ' . fnameescape(l:names[0])

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -6,9 +6,9 @@ fun! nnn#select_action(action)
     let s:action = a:action
     " quit nnn
     if has("nvim")
-        call feedkeys('iq')
+        call feedkeys("i\<cr>")
     else
-        call term_sendkeys(s:term_buff, 'q')
+        call term_sendkeys(s:term_buff, "\<cr>")
     endif
 endfun
 


### PR DESCRIPTION
At least partially since <kbd>enter</kbd> clears the selection. The feature where selecting multiple files and then display the first file in a split/vsplit/tab while other selected files are pushed in the buffer list is lost.