### PR TITLE
Customizable nnn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ selected file in a tab, instead of the current window. <kbd>ctrl-x</kbd> will
 open in a split an so on. Meanwhile for multi selected files will be loaded in the
 buffer list.
 
+#### Command override
+
+When you want to override the default nnn command and add some extra flags.
+Example you want to start nnn in light mode.
+
+```vim
+let g:nnn#command = 'nnn -l'
+
+" or pass some env variables
+let g:nnn#command = 'DISABLE_FILE_OPEN_ON_NAV=1 nnn -l'
+```
+
 #### `nnn#pick()`
 
 The `nnn#pick([<dir>][,<opts>])` function can be called with custom directory

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -103,7 +103,7 @@ fun! nnn#pick(...) abort
     let l:default_opts = { 'edit': 'edit' }
     let l:opts = extend(l:default_opts, get(a:, 2, {}))
     let s:temp = tempname()
-    let l:cmd = 'nnn -p ' . shellescape(s:temp) . ' ' . l:directory
+    let l:cmd = g:nnn#command.' -p '.shellescape(s:temp).' '.expand(l:directory)
     let l:layout = exists('l:opts.layout') ? l:opts.layout : g:nnn#layout
 
     exec s:eval_layout(l:layout)

--- a/plugin/nnn.vim
+++ b/plugin/nnn.vim
@@ -10,6 +10,10 @@ if !(exists("g:nnn#action"))
     let g:nnn#action = {}
 endif
 
+if !(exists("g:nnn#command"))
+    let g:nnn#command = 'nnn'
+endif
+
 " Breaking change notice
 fun! NnnPicker(...) abort
     throw 'NnnPicker() is renamed to nnn#pick()'


### PR DESCRIPTION
When you want to override the default nnn command and add some extra flags.
Example you want to start nnn in light mode.
```vim
let g:nnn#command = 'nnn -l'
" or pass some env variables
let g:nnn#command = 'DISABLE_FILE_OPEN_ON_NAV=1 nnn -l'
```

Closes #22 