### PR TITLE
Force default layout when replacing netrw

### DIFF
--- a/plugin/nnn.vim
+++ b/plugin/nnn.vim
@@ -39,7 +39,7 @@ if g:nnn#replace_netrw
     function! s:nnn_pick_on_load_dir(argv_path)
         let l:path = expand(a:argv_path)
         bdelete!
-        call nnn#pick(l:path)
+        call nnn#pick(l:path, {'layout': 'enew'})
     endfunction
 
     augroup ReplaceNetrwByNnnVim


### PR DESCRIPTION
Let nnn.vim take full width and height with default layout 'enew' when it's replacing netrw. 