### PR TITLE
Implement cd on quit

### DIFF
--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -265,6 +265,16 @@ function! s:create_on_exit_callback(opts)
         endif
 
         call s:eval_temp_file(l:opts)
+
+        let fdir = !empty($XDG_CONFIG_HOME) ? $XDG_CONFIG_HOME : $HOME.'/.config'
+        let fname = fdir . '/nnn/.lastd'
+        if !empty(glob(fname))
+            let firstline = readfile(fname)[0]
+            let lastd = split(firstline, '"')[1]
+            execute 'cd' fnameescape(lastd)
+            call delete(fnameescape(fname))
+        endif
+
     endfunction
     return function('s:callback')
 endfunction


### PR DESCRIPTION
Resolves https://github.com/mcchrish/nnn.vim/issues/57.

This allows using `^g` to *cd on quit* (as described [here](https://github.com/jarun/nnn/wiki/Basic-use-cases#configure-cd-on-quit)) using vim's nnn plugin.