### PR TITLE
Add try/catch for E211

### DIFF
--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -184,7 +184,12 @@ function! s:switch_back(opts, Cmd)
 
     " when split explorer
     if type(l:layout) == v:t_string && l:layout == 'enew' && bufexists(l:buf)
-        execute 'keepalt b' l:buf
+        try
+            execute 'keepalt b' l:buf
+        " in case nnn was used to delete file in open buffer
+        catch /E211: File/
+            let junk = input(matchstr(string(v:exception), 'E211: .*$') . "\nPress ENTER to continue")
+        endtry
         if bufexists(l:term_wins.term.buf)
             execute 'bwipeout!' l:term_wins.term.buf
         endif


### PR DESCRIPTION
In the case that nnn is used to remove a file while that file is in an
active buffer, Vim will raise E211 with trace on reentry from nnn. The
trace is somewhat of an eye sore but the E211 message is useful. This
PR adds a try catch for E211, removes the trace and reraises E211.

Fixes: #41