### PR TITLE
Don't expand path argument, can cause problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,8 @@ nnoremap <silent> <leader>nn :NnnPicker<CR>
 
 " Or override
 " Start nnn in the current file's directory
-nnoremap <leader>n :NnnPicker '%:p:h'<CR>
+nnoremap <leader>n :NnnPicker %:p:h<CR>
 ```
-
-Note: For fish shell, the single quotes around `'%:p:h'` should be dropped.
 
 #### Layout
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ nnoremap <silent> <leader>nn :NnnPicker<CR>
 nnoremap <leader>n :NnnPicker %:p:h<CR>
 ```
 
+_NOTE there are no quotes around `%:p:h` anymore - v1.7 and earlier versions suggested using quotes, but that can trigger a `E79: Cannot expand wildcards` error_
+
+
 #### Layout
 
 ```vim

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -331,7 +331,7 @@ function! nnn#pick(...) abort
     let l:default_opts = { 'edit': 'edit' }
     let l:opts = extend(l:default_opts, get(a:, 2, {}))
     let s:temp_file = tempname()
-    let l:cmd = g:nnn#command.' -p '.shellescape(s:temp_file).' '.shellescape(l:directory)
+    let l:cmd = g:nnn#command.' -p '.shellescape(s:temp_file).' '.(l:directory != '' ? shellescape(l:directory) : '')
     let l:layout = exists('l:opts.layout') ? l:opts.layout : g:nnn#layout
 
     let l:opts.layout = l:layout

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -327,11 +327,11 @@ endfunction
 
 
 function! nnn#pick(...) abort
-    let l:directory = expand(get(a:, 1, ""))
+    let l:directory = get(a:, 1, "")
     let l:default_opts = { 'edit': 'edit' }
     let l:opts = extend(l:default_opts, get(a:, 2, {}))
     let s:temp_file = tempname()
-    let l:cmd = g:nnn#command.' -p '.shellescape(s:temp_file).' '.expand(l:directory)
+    let l:cmd = g:nnn#command.' -p '.shellescape(s:temp_file).' '.shellescape(l:directory)
     let l:layout = exists('l:opts.layout') ? l:opts.layout : g:nnn#layout
 
     let l:opts.layout = l:layout


### PR DESCRIPTION
Hi there, me again.

I'm still having problems with the `%:p:h` argument for `:NnnPicker`.

The `expand` call seems to be the problem. I don't think it's needed, as Vim will already expand `%:p:h` when used in a mapping anyway.  But if left in, it seems to cause problems, incorrectly expanding the path to `""` in some situations. (which then opens nnn in the root of my project, rather than the directory of the file)

This seems to fix it for me.  I tested with both neovim and vim 8, in both fish and bash.

It is a breaking change though, because you have to set the mapping without quotes around `%:p:h`. Anyone using quotes previously would have to remove them.

