### PR TITLE
Ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
The doc/tags file should be ignored to make git-submodules work better. Otherwise, they will show as modified when you use git-submodules to manage your vim plugins.