### PR TITLE
Delete the nnn window on exit

### DIFF
--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -232,6 +232,10 @@ function! s:switch_back(opts, Cmd)
     if (type(a:Cmd) == v:t_string && a:Cmd != 'edit')
                 \ || (type(l:layout) != v:t_string
                 \ || (type(l:layout) == v:t_string && l:layout != 'enew'))
+        " delete the nnn window and buffer
+        if nvim_win_is_valid(l:term_wins.term.winhandle)
+            call nvim_win_close(l:term_wins.term.winhandle, v:false)
+        endif
         if bufexists(l:term_wins.term.buf)
             execute 'bwipeout!' l:term_wins.term.buf
         endif

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -233,8 +233,12 @@ function! s:switch_back(opts, Cmd)
                 \ || (type(l:layout) != v:t_string
                 \ || (type(l:layout) == v:t_string && l:layout != 'enew'))
         " delete the nnn window and buffer
-        if nvim_win_is_valid(l:term_wins.term.winhandle)
-            call nvim_win_close(l:term_wins.term.winhandle, v:false)
+        if has('nvim')
+            if nvim_win_is_valid(l:term_wins.term.winhandle)
+                call nvim_win_close(l:term_wins.term.winhandle, v:false)
+            endif
+        else
+            call popup_close(l:term_wins.term.winhandle)
         endif
         if bufexists(l:term_wins.term.buf)
             execute 'bwipeout!' l:term_wins.term.buf


### PR DESCRIPTION
Fixes #87 and prevents window from lingering. Helps fix bothersome
behavior with vim-startify such as keeping a lingering new tab and not
consuming original vim-startify window on exit.

The same check is ran for floating windows, but is currently not ran on
other layouts:
https://github.com/mcchrish/nnn.vim/blob/422cd80e35c81a303d16a600f549dc4d319cecf6/autoload/nnn.vim#L198-L228

It seems like a sensible thing to delete the nnn window regardless of
layout.