### PR TITLE
Sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ the buffer list.
 
 #### Persistent session
 
-You can configure n³ to use a session to remember your place when you reopen it.
+You can configure n³ to use a session so it remembers your place when
+you reopen it.
 
 ```vim
 " use the same nnn session within a vim session

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ let g:nnn#session = 'local'
 let g:nnn#session = 'global'
 ```
 
+Note: If desired, an n³ session can be disabled temporarily by passing
+`session: false` as an option to `nnn#pick()`.
+
 #### Command override
 
 When you want to override the default n³ command and add some extra flags.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ selected file in a tab, instead of the current window. <kbd>ctrl-x</kbd> will
 open in a split an so on. Meanwhile for multi selected files will be loaded in
 the buffer list.
 
+#### Persistent session
+
+You can configure n³ to use a session to remember your place when you reopen it.
+
+```vim
+" use the same nnn session within a vim session
+let g:nnn#session = 'local'
+
+" use the same nnn session everywhere (including outside vim)
+let g:nnn#session = 'global'
+```
+
 #### Command override
 
 When you want to override the default n³ command and add some extra flags.

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -351,6 +351,12 @@ function! nnn#pick(...) abort
         let l:sess_cfg = ' -S '
     elseif g:nnn#session ==# 'local'
         let l:sess_cfg = ' -S -s '.s:local_ses.' '
+        let session_file = s:nnn_conf_dir.'/sessions/'.s:local_ses
+        echom session_file
+        if !(exists('g:nnn_ses_autocmd'))
+            execute 'autocmd VimLeavePre * call delete(fnameescape("'.session_file.'"))'
+            let g:nnn_ses_autocmd = 1
+        endif
     endif
     let l:cmd = g:nnn#command.l:sess_cfg.' -p '.shellescape(s:temp_file).' '.(l:directory != '' ? shellescape(l:directory): '')
     let l:layout = exists('l:opts.layout') ? l:opts.layout : g:nnn#layout

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -1,6 +1,8 @@
 let s:temp_file = ""
 let s:action = ""
 let s:tbuf = 0
+" HACK: cannot use / in a session name
+let s:local_ses = substitute(tempname(), '/', '-', 'g')
 
 function! s:statusline()
     setlocal statusline=%#StatusLineTerm#\ nnn\ %#StatusLineTermNC#
@@ -342,7 +344,14 @@ function! nnn#pick(...) abort
     let l:default_opts = { 'edit': 'edit' }
     let l:opts = extend(l:default_opts, get(a:, 2, {}))
     let s:temp_file = tempname()
-    let l:cmd = g:nnn#command.' -p '.shellescape(s:temp_file).' '.(l:directory != '' ? shellescape(l:directory): '')
+    if g:nnn#session ==# 'none'
+        let l:sess_cfg = ' '
+    elseif g:nnn#session ==# 'global'
+        let l:sess_cfg = ' -S '
+    elseif g:nnn#session ==# 'local'
+        let l:sess_cfg = ' -S -s '.s:local_ses.' '
+    endif
+    let l:cmd = g:nnn#command.l:sess_cfg.' -p '.shellescape(s:temp_file).' '.(l:directory != '' ? shellescape(l:directory): '')
     let l:layout = exists('l:opts.layout') ? l:opts.layout : g:nnn#layout
 
     let l:opts.layout = l:layout

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -1,8 +1,14 @@
 let s:temp_file = ""
 let s:action = ""
 let s:tbuf = 0
+
 " HACK: cannot use / in a session name
-let s:local_ses = substitute(tempname(), '/', '-', 'g')
+let s:local_ses = 'nnn-vim-'.substitute(tempname(), '/', '-', 'g')
+" Add timestamp for convenience
+" :h strftime() -- strftime is not portable
+if exists('*strftime')
+    let s:local_ses .= '-'.strftime('%Y-%m-%dT%H:%M:%SZ')
+endif
 
 function! s:statusline()
     setlocal statusline=%#StatusLineTerm#\ nnn\ %#StatusLineTermNC#

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -2,12 +2,14 @@ let s:temp_file = ""
 let s:action = ""
 let s:tbuf = 0
 
-" HACK: cannot use / in a session name
-let s:local_ses = 'nnn_vim_'.substitute(tempname(), '/', '_', 'g')
+let s:local_ses = 'nnn_vim_'
 " Add timestamp for convenience
 " :h strftime() -- strftime is not portable
 if exists('*strftime')
-    let s:local_ses .= '_'.strftime('%Y_%m_%dT%H_%M_%SZ')
+    let s:local_ses .= strftime('%Y_%m_%dT%H_%M_%SZ')
+else
+    " HACK: cannot use / in a session name
+    let s:local_ses .= substitute(tempname(), '/', '_', 'g')
 endif
 
 function! s:statusline()

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -352,10 +352,7 @@ function! nnn#pick(...) abort
     elseif g:nnn#session ==# 'local'
         let l:sess_cfg = ' -S -s '.s:local_ses.' '
         let session_file = s:nnn_conf_dir.'/sessions/'.s:local_ses
-        if !(exists('g:nnn_ses_autocmd'))
-            execute 'autocmd VimLeavePre * call delete(fnameescape("'.session_file.'"))'
-            let g:nnn_ses_autocmd = 1
-        endif
+	execute 'augroup NnnSession | autocmd! VimLeavePre * call delete(fnameescape("'.session_file.'")) | augroup End'
     endif
     let l:cmd = g:nnn#command.l:sess_cfg.' -p '.shellescape(s:temp_file).' '.(l:directory != '' ? shellescape(l:directory): '')
     let l:layout = exists('l:opts.layout') ? l:opts.layout : g:nnn#layout

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -3,11 +3,11 @@ let s:action = ""
 let s:tbuf = 0
 
 " HACK: cannot use / in a session name
-let s:local_ses = 'nnn-vim-'.substitute(tempname(), '/', '-', 'g')
+let s:local_ses = 'nnn_vim_'.substitute(tempname(), '/', '_', 'g')
 " Add timestamp for convenience
 " :h strftime() -- strftime is not portable
 if exists('*strftime')
-    let s:local_ses .= '-'.strftime('%Y-%m-%dT%H:%M:%SZ')
+    let s:local_ses .= '_'.strftime('%Y_%m_%dT%H_%M_%SZ')
 endif
 
 function! s:statusline()

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -244,8 +244,8 @@ function! s:switch_back(opts, Cmd)
                 execute win_id2win(l:term_wins.term.winhandle) . 'close'
             endif
         catch /E444: Cannot close last window/
-	    " In case Vim complains it is the last window, fail silently.
-	endtry
+            " In case Vim complains it is the last window, fail silently.
+        endtry
         if bufexists(l:term_wins.term.buf)
             execute 'bwipeout!' l:term_wins.term.buf
         endif
@@ -345,6 +345,7 @@ function! nnn#pick(...) abort
     let l:default_opts = { 'edit': 'edit' }
     let l:opts = extend(l:default_opts, get(a:, 2, {}))
     let s:temp_file = tempname()
+
     if g:nnn#session ==# 'none' || !get(l:opts, 'session', 1)
         let l:sess_cfg = ' '
     elseif g:nnn#session ==# 'global'
@@ -352,10 +353,11 @@ function! nnn#pick(...) abort
     elseif g:nnn#session ==# 'local'
         let l:sess_cfg = ' -S -s '.s:local_ses.' '
         let session_file = s:nnn_conf_dir.'/sessions/'.s:local_ses
-	execute 'augroup NnnSession | autocmd! VimLeavePre * call delete(fnameescape("'.session_file.'")) | augroup End'
+        execute 'augroup NnnSession | autocmd! VimLeavePre * call delete(fnameescape("'.session_file.'")) | augroup End'
     else
         let l:sess_cfg = ' '
     endif
+
     let l:cmd = g:nnn#command.l:sess_cfg.' -p '.shellescape(s:temp_file).' '.(l:directory != '' ? shellescape(l:directory): '')
     let l:layout = exists('l:opts.layout') ? l:opts.layout : g:nnn#layout
 

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -352,7 +352,6 @@ function! nnn#pick(...) abort
     elseif g:nnn#session ==# 'local'
         let l:sess_cfg = ' -S -s '.s:local_ses.' '
         let session_file = s:nnn_conf_dir.'/sessions/'.s:local_ses
-        echom session_file
         if !(exists('g:nnn_ses_autocmd'))
             execute 'autocmd VimLeavePre * call delete(fnameescape("'.session_file.'"))'
             let g:nnn_ses_autocmd = 1

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -275,6 +275,8 @@ function! s:create_term_buf(opts)
     endif
 endfunction
 
+let s:nnn_conf_dir = (!empty($XDG_CONFIG_HOME) ? $XDG_CONFIG_HOME : $HOME.'/.config') . '/nnn'
+
 function! s:create_on_exit_callback(opts)
     let l:opts = a:opts
     function! s:callback(id, code, ...) closure
@@ -285,8 +287,7 @@ function! s:create_on_exit_callback(opts)
 
         call s:eval_temp_file(l:opts)
 
-        let fdir = !empty($XDG_CONFIG_HOME) ? $XDG_CONFIG_HOME : $HOME.'/.config'
-        let fname = fdir . '/nnn/.lastd'
+        let fname = s:nnn_conf_dir.'/.lastd'
         if !empty(glob(fname))
             let firstline = readfile(fname)[0]
             let lastd = split(firstline, '"')[1]

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -345,7 +345,7 @@ function! nnn#pick(...) abort
     let l:default_opts = { 'edit': 'edit' }
     let l:opts = extend(l:default_opts, get(a:, 2, {}))
     let s:temp_file = tempname()
-    if g:nnn#session ==# 'none'
+    if g:nnn#session ==# 'none' || !get(l:opts, 'session', 1)
         let l:sess_cfg = ' '
     elseif g:nnn#session ==# 'global'
         let l:sess_cfg = ' -S '
@@ -353,6 +353,8 @@ function! nnn#pick(...) abort
         let l:sess_cfg = ' -S -s '.s:local_ses.' '
         let session_file = s:nnn_conf_dir.'/sessions/'.s:local_ses
 	execute 'augroup NnnSession | autocmd! VimLeavePre * call delete(fnameescape("'.session_file.'")) | augroup End'
+    else
+        let l:sess_cfg = ' '
     endif
     let l:cmd = g:nnn#command.l:sess_cfg.' -p '.shellescape(s:temp_file).' '.(l:directory != '' ? shellescape(l:directory): '')
     let l:layout = exists('l:opts.layout') ? l:opts.layout : g:nnn#layout

--- a/doc/nnn.txt
+++ b/doc/nnn.txt
@@ -44,7 +44,8 @@ buffer opens running an n³ process in picker mode.
 Once you select (see https://github.com/jarun/nnn/wiki/concepts#selection)
 one or more files and press enter, vim quits the n³ window and opens the
 first selected file and add the remaining files to the arg list/buffer
-list.
+list. If |nnn#session| is enabled, then n³ will remember where you left off
+of when you reopen it.
 
 Pressing enter on a file in n³ will pick any earlier selection, pick
 the file and exit n³.
@@ -144,6 +145,19 @@ g:nnn#action                                                     *g:nnn#action*
                     echom joined_lines
                     let @+ = joined_lines
                   endfunction
+<
+
+g:nnn#session                                                   *g:nnn#session*
+                  Default: 'none'
+                  How n³ should utilize sessions. Default is 'none' meaning no
+                  persistent sessions. Other options are 'local' for the same
+                  n³ session across a vim session, or 'global' for the same n³
+                  session across everywhere.
+>
+                  " use the same nnn session within a vim session, for
+                  " example, so that consecutive uses of :Np will remember
+                  " where you last left off
+                  let g:nnn#session = 'local'
 <
 
 g:nnn#command                                                   *g:nnn#command*

--- a/plugin/nnn.vim
+++ b/plugin/nnn.vim
@@ -31,6 +31,10 @@ if !(exists("g:nnn#shell"))
     let g:nnn#shell = &shell
 endif
 
+if !(exists("g:nnn#session"))
+   let g:nnn#session = "none"
+endif
+
 command! -bar -nargs=? -complete=dir NnnPicker call nnn#pick(<f-args>)
 command! -bar -nargs=? -complete=dir Np call nnn#pick(<f-args>)
 


### PR DESCRIPTION
Add support for sessions in nnn.vim. Three options are provided:
1) `g:nnn#session = 'none'` for no session (default)
2) `g:nnn#session = 'local'` for the same nnn session to be used within one vim instance
3) `g:nnn#session = 'global'` to use the same global auto session (`@`)