### PR TITLE
File explorer (a.k.a. persistent picker)

### DIFF
--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -438,6 +438,7 @@ function! nnn#pick(...) abort
     let l:opts.term_wins = s:build_window(l:layout, { 'cmd': l:cmd, 'on_exit': l:On_exit })
     let s:tbuf = l:opts.term_wins.term.buf
 
+    autocmd BufEnter <buffer> startinsert
     setfiletype nnn
     if g:nnn#statusline && type(l:layout) == v:t_string
         call s:statusline()
@@ -463,6 +464,7 @@ function! nnn#explorer(...) abort
 
     call s:explorer_job()
 
+    autocmd BufEnter <buffer> startinsert
     setfiletype nnn
     if g:nnn#statusline && type(l:layout) == v:t_string
         call s:statusline()

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -347,6 +347,31 @@ function! s:build_window(layout, term_opts)
     throw 'Invalid layout'
 endfunction
 
+" adapted from NERDTree source code
+function! s:explorer_jump_to_buffer(fname)
+    let l:winnr = bufwinnr('^' . a:fname . '$')
+
+    if l:winnr !=# -1
+        " jump to the window if it's already displayed
+        execute l:winnr . 'wincmd w'
+    else
+        " if not, there are some options here: we can allow the user to choose,
+        " but a sane default is to open it in the previous window
+        " NOTE: this can go to "special" windows like qflist
+        let l:winnr = winnr('#')
+        execute l:winnr . 'wincmd w'
+        execute 'edit ' . a:fname
+    endif
+endfunction
+
+function! s:explorer_on_output(...)
+    let l:fname = has('nvim') ? a:2[0] : a:2
+    if l:fname ==# ''
+        return
+    endif
+    call s:explorer_jump_to_buffer(l:fname)
+endfunction
+
 
 function! nnn#pick(...) abort
     let l:directory = get(a:, 1, '')

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -437,6 +437,32 @@ function! nnn#pick(...) abort
 
     let l:opts.term_wins = s:build_window(l:layout, { 'cmd': l:cmd, 'on_exit': l:On_exit })
     let s:tbuf = l:opts.term_wins.term.buf
+
+    setfiletype nnn
+    if g:nnn#statusline && type(l:layout) == v:t_string
+        call s:statusline()
+    endif
+endfunction
+
+function! nnn#explorer(...) abort
+    let l:directory = get(a:, 1, '')
+    let l:default_opts = { 'edit': 'edit' }
+    let l:opts = extend(l:default_opts, get(a:, 2, {}))
+    let s:explorer_fifo = tempname()
+
+    let l:cmd = g:nnn#command.' -X '.shellescape(s:explorer_fifo).' '.(l:directory != '' ? shellescape(l:directory): '')
+
+    let l:layout = exists('l:opts.layout') ? l:opts.layout : g:nnn#explorer_layout
+
+    let l:opts.layout = l:layout
+    let l:opts.ppos = { 'buf': bufnr(''), 'win': winnr(), 'tab': tabpagenr() }
+    let l:On_exit = s:explorer_create_on_exit_callback(l:opts)
+
+    let l:opts.term_wins = s:build_window(l:layout, { 'cmd': l:cmd, 'on_exit': l:On_exit })
+    let s:tbuf = l:opts.term_wins.term.buf
+
+    call s:explorer_job()
+
     setfiletype nnn
     if g:nnn#statusline && type(l:layout) == v:t_string
         call s:statusline()

--- a/plugin/nnn.vim
+++ b/plugin/nnn.vim
@@ -11,6 +11,10 @@ if !(exists("g:nnn#layout"))
     let g:nnn#layout = 'enew'
 endif
 
+if !(exists("g:nnn#explorer_layout"))
+    let g:nnn#explorer_layout = { 'left': '20%' }
+endif
+
 if !(exists("g:nnn#action"))
     let g:nnn#action = {}
 endif


### PR DESCRIPTION
Not ready to merge yet, but I'd like a review. There are a number of outstanding issues:

1. If a floating nnn window is used alongside the file explorer, the value of `s:tbuf` is overwritten and it is borked (not _horrible_ though, still usable).
2. Entering and leaving the file explorer window will be a common part of a workflow, but normal window commands cannot be used to leave the window because it is in insert mode in the terminal. (For _entering_ the window, I add an autocommand in b3df46d which works great).
3. I add a 0.5-second delay before I start to "watch" the FIFO since I'm currently relying on `nnn` to create the FIFO. I could also create the FIFO within the plugin before starting the `nnn` process.
4. There is quite a bit of code duplication between `nnn#pick()` and `nnn#explorer()` as well as between `s:explorer_create_on_exit_callback()` and `s:switch_back()`. Would you like me to extract common parts out into separate functions?

Those are the issues I can think of at the moment, there may very well be more. 