### PR TITLE
change default layout to enew on vim

### DIFF
--- a/doc/nnn.txt
+++ b/doc/nnn.txt
@@ -95,7 +95,9 @@ g:nnn#set_default_mappings                         *g:nnn#set_default_mappings*
 <
 
 g:nnn#layout                                                     *g:nnn#layout*
-                  Default: { 'window': { 'width': 0.9, 'height': 0.6 } }
+                  Default:
+                    neovim: { 'window': { 'width': 0.9, 'height': 0.6 } }
+                    vim: 'enew'
                   Display type for the n³ buffer. Default is a floating
                   window. |enew| has a special behavior to act as a
                   "split explorer" reusing the current window and brings back

--- a/plugin/nnn.vim
+++ b/plugin/nnn.vim
@@ -6,7 +6,7 @@ let g:nnn#loaded = 1
 let g:nnn#has_floating_window_support = has('nvim-0.5') || has('popupwin')
 
 if !exists('g:nnn#layout')
-    if g:nnn#has_floating_window_support
+    if g:nnn#has_floating_window_support && has('nvim')
         let g:nnn#layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
     else
         let g:nnn#layout = 'enew'


### PR DESCRIPTION
After switching to vim from neovim, I noticed that the floating nnn terminal was quite unusable due to the scrolling bug. The nnn contexts/tabs would also randomly not render/display for me.
I think it makes sense not to use it as a default for vim considering the related issues are closed and there seems to be no interest in fixing it.