### PR TITLE
create fifo before calling s:build_window

### DIFF
--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -385,11 +385,11 @@ function! nnn#explorer(...) abort
     let l:opts.ppos = { 'buf': bufnr(''), 'win': winnr(), 'tab': tabpagenr() }
     let l:On_exit = s:explorer_create_on_exit_callback(l:opts)
 
+    " create the fifo ourselves since otherwise nnn might not create it on time
+    execute 'silent !mkfifo '.s:explorer_fifo
     let l:opts.term = s:build_window(l:layout, { 'cmd': l:cmd, 'on_exit': l:On_exit })
     let b:tbuf = l:opts.term
 
-    " create the fifo ourselves since otherwise nnn might not create it on time
-    execute 'silent !mkfifo '.s:explorer_fifo
     call s:explorer_job()
 
     autocmd BufEnter <buffer> startinsert


### PR DESCRIPTION
otherwise nnn might end up creating a fifo before us.

Closes: https://github.com/mcchrish/nnn.vim/pull/125#issuecomment-948096426