### PR TITLE
fix: mouse not working

### DIFF
--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -199,7 +199,7 @@ function! s:create_term_buf(opts)
     let l:shell = get(g:, 'nnn#shell', &shell)
     if has('nvim')
         call termopen([l:shell, &shellcmdflag, a:opts.cmd], {
-                    \ 'env': { 'NNN_SEL': s:temp_file },
+                    \ 'env': { 'NNN_SEL': s:temp_file, 'TERM': $TERM },
                     \ 'on_exit': a:opts.on_exit
                     \ })
         startinsert
@@ -208,7 +208,7 @@ function! s:create_term_buf(opts)
         return term_start([l:shell, &shellcmdflag, a:opts.cmd], {
                     \ 'curwin': get(a:opts, 'curwin', 1),
                     \ 'hidden': get(a:opts, 'hidden', 0),
-                    \ 'env': { 'NNN_SEL': s:temp_file },
+                    \ 'env': { 'NNN_SEL': s:temp_file, 'TERM': $TERM },
                     \ 'exit_cb': a:opts.on_exit,
                     \ 'term_kill': 'term'
                     \ })


### PR DESCRIPTION
curses needs $TERM in order to enable mouse events.

for relevant discussion, see:
https://github.com/jarun/nnn/commit/00c73512b98ad0e02068f38051664ca3e23997cc