### PR TITLE
Fix any issues related to explorer-toggle

### DIFF
--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -321,7 +321,7 @@ function! s:explorer_create_on_exit_callback(opts)
                     call nvim_win_close(l:term.winhandle, v:false)
                 endif
             else
-                execute win_id2win(l:term.winhandle) . 'close'
+                call win_execute(l:term.winhandle, 'close')
             endif
         catch /E444: Cannot close last window/
             " In case Vim complains it is the last window, fail silently.

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -321,7 +321,7 @@ function! s:explorer_create_on_exit_callback(opts)
                     call nvim_win_close(l:term.winhandle, v:false)
                 endif
             else
-                call win_execute(l:term.winhandle, 'close')
+                execute win_id2win(l:term.winhandle) . 'close'
             endif
         catch /E444: Cannot close last window/
             " In case Vim complains it is the last window, fail silently.
@@ -367,7 +367,7 @@ endfunction
 function! nnn#explorer(...) abort
     " toggle/close the explorer if it already exists
     if exists('t:explorer_winid') && t:explorer_winid > 0
-        call win_execute(t:explorer_winid, 'close!')
+        execute win_id2win(t:explorer_winid) . 'close!'
         return
     endif
 

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -329,9 +329,7 @@ function! s:explorer_create_on_exit_callback(opts)
         if bufexists(l:term.buf)
             execute 'bwipeout!' l:term.buf
         endif
-        if exists('t:explorer_winid')
-            let t:explorer_winid = 0
-        endif
+        let t:explorer_winid = 0
     endfunction
     return function('s:explorer_callback')
 endfunction

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -329,6 +329,9 @@ function! s:explorer_create_on_exit_callback(opts)
         if bufexists(l:term.buf)
             execute 'bwipeout!' l:term.buf
         endif
+        if exists('t:explorer_winid')
+            let t:explorer_winid = 0
+        endif
     endfunction
     return function('s:explorer_callback')
 endfunction
@@ -367,7 +370,6 @@ function! nnn#explorer(...) abort
     " toggle/close the explorer if it already exists
     if exists('t:explorer_winid') && t:explorer_winid > 0
         call win_execute(t:explorer_winid, 'close!')
-        let t:explorer_winid = 0
         return
     endif
 


### PR DESCRIPTION
- [x] quitting explorer normally doesn't clear `explorer_winid` (https://github.com/mcchrish/nnn.vim/pull/140/commits/13f179490f53dc39c172d11ca31f855acc8fe369)
- [x] on `vim` `:NnnExplorer` ends up closing the current buffer as well as the explorer buffer. (doesn't happen on `nvim`) (https://github.com/mcchrish/nnn.vim/pull/140/commits/b7bae695492349865dad7373d28567dcb3b217b3)
- [x] triggering the above also leads to opening up multiple explorer instances (https://github.com/mcchrish/nnn.vim/pull/140/commits/b7bae695492349865dad7373d28567dcb3b217b3)