### PR TITLE
use tab-local variables for explorer exit callback

### DIFF
--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -312,7 +312,6 @@ endfunction
 function! s:explorer_create_on_exit_callback()
     function! s:explorer_callback(id, code, ...) closure
         let l:term = t:explorer_term
-        let l:buf = t:explorer_ppos.buf
         call delete(fnameescape(s:explorer_fifo))
         " same code as in the bottom of s:switch_back()
         try
@@ -386,19 +385,15 @@ function! nnn#explorer(...) abort
     let l:cmd .= '-F 1 '.(l:directory != '' ? shellescape(l:directory): '')
 
     let l:layout = exists('l:opts.layout') ? l:opts.layout : g:nnn#explorer_layout
-
     let l:opts.layout = l:layout
-    let l:opts.ppos = { 'buf': bufnr(''), 'winid': win_getid() }
-    let l:On_exit = s:explorer_create_on_exit_callback()
 
     " create the fifo ourselves since otherwise nnn might not create it on time
     call system('mkfifo '.shellescape(s:explorer_fifo))
-    let l:opts.term = s:build_window(l:layout, { 'cmd': l:cmd, 'on_exit': l:On_exit })
+    let l:On_exit = s:explorer_create_on_exit_callback()
+    let b:tbuf = s:build_window(l:layout, { 'cmd': l:cmd, 'on_exit': l:On_exit })
 
-    let b:tbuf = l:opts.term
-    let t:explorer_winid = l:opts.term.winhandle
-    let t:explorer_term = l:opts.term
-    let t:explorer_ppos = l:opts.ppos
+    let t:explorer_winid = b:tbuf.winhandle
+    let t:explorer_term = b:tbuf
 
     call s:explorer_job()
 

--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -309,10 +309,10 @@ function! s:explorer_job()
     endif
 endfunction
 
-function! s:explorer_create_on_exit_callback(opts)
+function! s:explorer_create_on_exit_callback()
     function! s:explorer_callback(id, code, ...) closure
-        let l:term = a:opts.term
-        let l:buf = a:opts.ppos.buf
+        let l:term = t:explorer_term
+        let l:buf = t:explorer_ppos.buf
         call delete(fnameescape(s:explorer_fifo))
         " same code as in the bottom of s:switch_back()
         try
@@ -321,7 +321,7 @@ function! s:explorer_create_on_exit_callback(opts)
                     call nvim_win_close(l:term.winhandle, v:false)
                 endif
             else
-                execute win_id2win(l:term.winhandle) . 'close'
+                call win_execute(l:term.winhandle, 'close')
             endif
         catch /E444: Cannot close last window/
             " In case Vim complains it is the last window, fail silently.
@@ -389,7 +389,7 @@ function! nnn#explorer(...) abort
 
     let l:opts.layout = l:layout
     let l:opts.ppos = { 'buf': bufnr(''), 'winid': win_getid() }
-    let l:On_exit = s:explorer_create_on_exit_callback(l:opts)
+    let l:On_exit = s:explorer_create_on_exit_callback()
 
     " create the fifo ourselves since otherwise nnn might not create it on time
     call system('mkfifo '.shellescape(s:explorer_fifo))
@@ -397,6 +397,8 @@ function! nnn#explorer(...) abort
 
     let b:tbuf = l:opts.term
     let t:explorer_winid = l:opts.term.winhandle
+    let t:explorer_term = l:opts.term
+    let t:explorer_ppos = l:opts.ppos
 
     call s:explorer_job()
 


### PR DESCRIPTION
Closes: https://github.com/mcchrish/nnn.vim/issues/141

- - -

The patch is still a bit messy and could use some cleanup.

But first I'd like to see if any weird environment specific behavior comes up. For example using `execute win_id2win(l:term.winhandle) . 'close'` in `vim` (neovim works fine) was resulting wiping the regular buffer as well while `call win_execute(l:term.winhandle, 'close')` works fine.