### PR TITLE
Always start terminal-mode for vim

### DIFF
--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -396,8 +396,6 @@ function! nnn#explorer(...) abort
     let t:explorer_term = b:tbuf
 
     call s:explorer_job()
-
-    autocmd BufEnter <buffer> startinsert
     setfiletype nnn
 endfunction
 

--- a/ftplugin/nnn.vim
+++ b/ftplugin/nnn.vim
@@ -25,6 +25,12 @@ if !exists('w:is_nnn_float')
             autocmd BufLeave <buffer> setl wincolor=NnnNormalNC
         augroup END
     endif
+
+    if has('nvim')
+        autocmd BufEnter <buffer> startinsert
+    else
+        autocmd BufEnter <buffer> if term_getstatus(bufnr()) =~# 'normal' | call feedkeys('i', 't') | endif
+    endif
 endif
 
 if !exists('g:nnn#statusline') || g:nnn#statusline

--- a/ftplugin/nnn.vim
+++ b/ftplugin/nnn.vim
@@ -25,12 +25,12 @@ if !exists('w:is_nnn_float')
             autocmd BufLeave <buffer> setl wincolor=NnnNormalNC
         augroup END
     endif
+endif
 
-    if has('nvim')
-        autocmd BufEnter <buffer> startinsert
-    else
-        autocmd BufEnter <buffer> if term_getstatus(bufnr()) =~# 'normal' | call feedkeys('i', 't') | endif
-    endif
+if has('nvim')
+    autocmd BufEnter <buffer> startinsert
+else
+    autocmd BufEnter <buffer> if term_getstatus(bufnr()) =~# 'normal' | call feedkeys('i', 't') | endif
 endif
 
 if !exists('g:nnn#statusline') || g:nnn#statusline


### PR DESCRIPTION
startinsert does not work in vim terminal-mode.
Simulate the behavior by sending 'i' key to the buffer.