### PR TITLE
Simply map <c-w> to normal mode <c-w>

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,6 @@ let g:nnn#set_default_mappings = 0
 " Set custom mappings
 nnoremap <silent> <leader>nn :NnnPicker<CR>
 
-" Switch away from file-explorer (assuming left sided) via <C-l>
-autocmd FileType nnn tnoremap <buffer><silent> <C-l> <C-\><C-n><C-w>l
-
 " Start n³ in the current file's directory
 nnoremap <leader>n :NnnPicker %:p:h<CR>
 ```

--- a/doc/nnn.txt
+++ b/doc/nnn.txt
@@ -91,14 +91,13 @@ Commands                                                         *nnn-commands*
 -----------------------------------------------------------------------------
 Mappings                                                         *nnn-mappings*
 
-Defaults mappings. Can be disabled by setting |g:nnn#set_default_mappings| to
-0.
+Default mappings. Can be disabled by setting |g:nnn#set_default_mappings| to 0.
 
 <leader>n
                   Runs |:NnnPicker|.
-<C-w>h/j/k/l
-                  Switches out of the nnn window.
-                  Useful when using explorer mode.
+<C-w>
+                  Window navigation prefix key. Same as <C-\><C-n><C-w> or
+                  <C-w> in normal mode.
 
 
 -----------------------------------------------------------------------------
@@ -114,9 +113,6 @@ g:nnn#set_default_mappings                         *g:nnn#set_default_mappings*
 
                   " Set your own
                   nnoremap <silent> <leader>nn :NnnPicker<CR>
-
-                  " Switch away from file-explorer (assuming left sided) via <C-l>
-                  autocmd FileType nnn tnoremap <buffer><silent> <C-l> <C-\><C-n><C-w>l
 
                   " Or override
                   " Start n³ in the current file's directory

--- a/ftplugin/nnn.vim
+++ b/ftplugin/nnn.vim
@@ -7,12 +7,7 @@ for key in keys(g:nnn#action)
     execute 'tnoremap <nowait><buffer><silent>' key '<c-\><c-n>:<c-u>call nnn#select_action("'.substitute(key, '<', '<lt>', 'g').'")<cr>'
 endfor
 
-if g:nnn#set_default_mappings
-    tnoremap <buffer><silent> <C-w>l <C-\><C-n><C-w>l
-    tnoremap <buffer><silent> <C-w>h <C-\><C-n><C-w>h
-    tnoremap <buffer><silent> <C-w>j <C-\><C-n><C-w>j
-    tnoremap <buffer><silent> <C-w>k <C-\><C-n><C-w>k
-endif
+tnoremap <buffer><silent> <C-w> <C-\><C-n><C-w>
 
 if !exists('w:is_nnn_float')
     if has('nvim')

--- a/ftplugin/nnn.vim
+++ b/ftplugin/nnn.vim
@@ -7,7 +7,9 @@ for key in keys(g:nnn#action)
     execute 'tnoremap <nowait><buffer><silent>' key '<c-\><c-n>:<c-u>call nnn#select_action("'.substitute(key, '<', '<lt>', 'g').'")<cr>'
 endfor
 
-tnoremap <buffer><silent> <C-w> <C-\><C-n><C-w>
+if g:nnn#set_default_mappings
+    tnoremap <buffer><silent> <C-w> <C-\><C-n><C-w>
+endif
 
 if !exists('w:is_nnn_float')
     if has('nvim')


### PR DESCRIPTION
I think we can just map <c-w> to normal mode <c-w> that wall all <c-w> will just work not just the four mappings we created.

Also I think it make sense that it should always be mapped regardless of `set_default_mappings`. `set_default_mappings` is if they want to get rid of `<leader>n`.