### PR TITLE
Fix issue #62 (scroll problem in popup window when using vim)

### DIFF
--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -141,7 +141,7 @@ function! s:popup(opts, term_opts)
         call setwinvar(l:win, 'is_nnn_float', v:true)
         return { 'buf': s:create_term_buf(a:term_opts), 'winhandle': l:win }
     else
-        let l:buf = s:create_term_buf(extend(a:term_opts, #{ curwin: 0, hidden: 1 }))
+        let l:buf = s:create_term_buf(extend(a:term_opts, #{ curwin: 0, hidden: 1, term_rows: height, term_cols: width }))
         let l:borderchars = l:border ==# 'rounded'
                     \ ? ['─', '│', '─', '│', '╭', '╮','╯' , '╰']
                     \ : ['─', '│', '─', '│', '┌', '┐', '┘', '└']
@@ -202,13 +202,23 @@ function! s:create_term_buf(opts)
         startinsert
         return bufnr('')
     else
-        return term_start([l:shell, &shellcmdflag, a:opts.cmd], {
+        let l:aux = {
                     \ 'curwin': get(a:opts, 'curwin', 1),
                     \ 'hidden': get(a:opts, 'hidden', 0),
                     \ 'env': { 'NNN_SEL': s:temp_file, 'TERM': $TERM },
                     \ 'exit_cb': a:opts.on_exit,
                     \ 'term_kill': 'term'
-                    \ })
+                    \ }
+        
+        if has_key(a:opts, 'term_rows')
+            call extend(l:aux, #{term_rows: get(a:opts, 'term_rows')})
+        endif
+
+        if has_key(a:opts, 'term_cols')
+            call extend(l:aux, #{term_cols: get(a:opts, 'term_cols')})
+        endif
+
+        return term_start([l:shell, &shellcmdflag, a:opts.cmd], l:aux)
     endif
 endfunction
 

--- a/doc/nnn.txt
+++ b/doc/nnn.txt
@@ -120,13 +120,11 @@ g:nnn#set_default_mappings                         *g:nnn#set_default_mappings*
 <
 
 g:nnn#layout                                                     *g:nnn#layout*
-                  Default:
-                    neovim: { 'window': { 'width': 0.9, 'height': 0.6 } }
-                    vim: 'enew'
-                  Display type for the n³ buffer. Default is a floating window
-                  on neovim and |enew| on vim. |enew| has a special behavior
-                  to act as a "split explorer" reusing the current window and
-                  brings back the last buffer if nothing is selected.
+                  Default: { 'window': { 'width': 0.9, 'height': 0.6 } }
+                  Display type for the n³ buffer. Default is a floating
+                  window. |enew| has a special behavior to act as a
+                  "split explorer" reusing the current window and brings back
+                  the last buffer if nothing is selected.
                   Examples:
 >
                   " Opens the n³ window in a split

--- a/plugin/nnn.vim
+++ b/plugin/nnn.vim
@@ -6,7 +6,7 @@ let g:nnn#loaded = 1
 let g:nnn#has_floating_window_support = has('nvim-0.5') || has('popupwin')
 
 if !exists('g:nnn#layout')
-    if g:nnn#has_floating_window_support && has('nvim')
+    if g:nnn#has_floating_window_support
         let g:nnn#layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
     else
         let g:nnn#layout = 'enew'


### PR DESCRIPTION
It looks like vim requires the terminal size to be specified in the
term_start() function (which must match the size of the popup windows)
or else it will create a "virtual" buffer bigger than what is displayed,
causing scroll artifacts.