### PR TITLE
Check for empty dictionary

### DIFF
--- a/ftplugin/nnn.vim
+++ b/ftplugin/nnn.vim
@@ -3,9 +3,11 @@ if exists('b:nnn_ftplugin')
 endif
 let b:nnn_ftplugin = 1
 
-for key in keys(g:nnn#action)
-    execute 'tnoremap <nowait><buffer><silent>' key '<c-\><c-n>:<c-u>call nnn#select_action("'.substitute(key, '<', '<lt>', 'g').'")<cr>'
-endfor
+if !empty(g:nnn#action)
+    for key in keys(g:nnn#action)
+        execute 'tnoremap <nowait><buffer><silent>' key '<c-\><c-n>:<c-u>call nnn#select_action("'.substitute(key, '<', '<lt>', 'g').'")<cr>'
+    endfor
+endif
 
 if g:nnn#set_default_mappings
     tnoremap <buffer><silent> <C-w> <C-\><C-n><C-w>


### PR DESCRIPTION
I found a small issue. If the `nnn#action` dictionary happens to be empty then the plugin will complain. I fixed it by checking that it's not empty first. 

![nnn_picker_error](https://github.com/mcchrish/nnn.vim/assets/3200308/bfa5ce8b-ea50-41f4-b846-1356604a4b83)
