### PR TITLE
fix(autoload/nnn.vim): Guard irregular return format in lastd

### DIFF
--- a/autoload/nnn.vim
+++ b/autoload/nnn.vim
@@ -235,8 +235,11 @@ function! s:create_on_exit_callback(opts)
         let fname = s:nnn_conf_dir.'/.lastd'
         if !empty(glob(fname))
             let firstline = readfile(fname)[0]
-            let lastd = split(firstline, '"')[1]
-            execute 'cd' fnameescape(lastd)
+            let parts = split(firstline, '"')
+            if len(parts) > 1
+                let lastd = parts[1]
+                execute 'cd' fnameescape(lastd)
+            endif
             call delete(fnameescape(fname))
         endif
     endfunction


### PR DESCRIPTION
Quitting with "q" using NnnPicker returns errors to the user. This makes the value of lastd regular in that case so it's safe to quit/abort a NnnPicker window having not selected anything.

Fixes #167 